### PR TITLE
Add GitHub alert for Minecraft version matching in setup instructions

### DIFF
--- a/SETUP.md
+++ b/SETUP.md
@@ -49,11 +49,14 @@ To join the server yourself and see your bots in action, you'll need a Minecraft
 1. Create an account at [tlauncher.org](https://tlauncher.org/) if you don't already have one
 2. Download TLauncher and install it
 3. Log in and pick a username (this is what you'll pass as `--player` to your bots)
-4. Select **OptiFine** as the version, and make sure the Minecraft version matches your PaperMC server (e.g. if your server is 1.21.4, select OptiFine 1.21.4)
+4. Select **OptiFine** as the version (use the same Minecraft version as your PaperMC server)
 5. Click **Enter the game**
 6. Once in the main menu, go to **Multiplayer** → **Add Server**
    - Server Address: `localhost:25565`
    - Click **Done**, then join the server
+
+> [!NOTE]
+> In step 4, make sure to select the Minecraft version you noted in step 3.1 (e.g. OptiFine 1.21.4 for a 1.21.4 server).
 
 You should now be in your local server. Leave it running while you work through the tutorials.
 


### PR DESCRIPTION
Reformats the setup instructions by extracting the Minecraft version‑matching guidance into a standalone GitHub alert block, moving it out of the step list, adjusting indentation for correct rendering, and adding a brief hint that references the earlier step.